### PR TITLE
Increase timeouts

### DIFF
--- a/instronSup/devinstron.proto
+++ b/instronSup/devinstron.proto
@@ -3,9 +3,9 @@
 #
 # Empirically, these timeouts appear to be enough to overcome the "hang"...
 #
-ReadTimeout = 1000;
-ReplyTimeout = 1000;
-WriteTimeout = 1000;
+ReadTimeout = 2500;
+ReplyTimeout = 2500;
+WriteTimeout = 2500;
 
 #
 # Individual commands


### PR DESCRIPTION
Increases the timeouts on the instron.

https://github.com/ISISComputingGroup/IBEX/issues/2802

This appeared to help communication with the device (50kN rig). 